### PR TITLE
Fix style element references to consistently use html:StyleSheet

### DIFF
--- a/specification/html - core.trig
+++ b/specification/html - core.trig
@@ -264,7 +264,7 @@ html:Element
     ├── html:Template
     ├── html:RawTextElement
     │    ├── html:Script
-    │    └── html:Style
+    │    └── html:StyleSheet
     ├── html:ForeignElement
     │    ├── mathml:MathML
     │    └── svg:Svg
@@ -2160,7 +2160,7 @@ This can be rendered in RDF using the HTML vocabulary as follows:
   html:MetadataContent
     rdf:type owl:Class;
     rdfs:subClassOf html:ContentCategory;
-    owl:unionOf (html:Base html:Link html:Meta html:Noscript html:Script html:Style html:Template html:Title);
+    owl:unionOf (html:Base html:Link html:Meta html:Noscript html:Script html:StyleSheet html:Template html:Title);
     dct:conformsTo section:3.2.5.2.1;
     skos:definition 'Metadata content is content that sets up the presentation or behavior of the rest of the content, or that sets up the relationship of the document with other documents, or that conveys other "out of band" information.'@en;
     skos:prefLabel 'Metadata content'@en;
@@ -4181,7 +4181,7 @@ This can be rendered in RDF using the HTML vocabulary as follows:
         owl:unionOf
           ( html:Link
             html:Script
-            html:Style ) ];
+            html:StyleSheet ) ];
     rdfs:range xsd:string;
     skos:definition "Indicates that the fetching of a resource should block the loading of the page until the resource is fetched."@en;
     skos:prefLabel 'the blocking attribute'@en;

--- a/tools/RDF2HTML/output/Example-serialized.trig
+++ b/tools/RDF2HTML/output/Example-serialized.trig
@@ -5454,7 +5454,7 @@ html:Element
     ├── html:Template
     ├── html:RawTextElement
     │    ├── html:Script
-    │    └── html:Style
+    │    └── html:StyleSheet
     ├── html:ForeignElement
     │    ├── mathml:MathML
     │    └── svg:Svg
@@ -6466,7 +6466,7 @@ The RDFa vocabulary is an RDF-based representation of RDFa, a W3C standard for r
     _:nee06a6e3cdbc4e7bb4f60cae8aede0f4b249 rdf:first html:Em ;
         rdf:rest _:nee06a6e3cdbc4e7bb4f60cae8aede0f4b250 .
 
-    _:nee06a6e3cdbc4e7bb4f60cae8aede0f4b25 rdf:first html:Style ;
+    _:nee06a6e3cdbc4e7bb4f60cae8aede0f4b25 rdf:first html:StyleSheet ;
         rdf:rest _:nee06a6e3cdbc4e7bb4f60cae8aede0f4b26 .
 
     _:nee06a6e3cdbc4e7bb4f60cae8aede0f4b250 rdf:first html:Embed ;
@@ -7189,7 +7189,7 @@ The RDFa vocabulary is an RDF-based representation of RDFa, a W3C standard for r
     _:nee06a6e3cdbc4e7bb4f60cae8aede0f4b466 rdf:first html:Script ;
         rdf:rest _:nee06a6e3cdbc4e7bb4f60cae8aede0f4b467 .
 
-    _:nee06a6e3cdbc4e7bb4f60cae8aede0f4b467 rdf:first html:Style ;
+    _:nee06a6e3cdbc4e7bb4f60cae8aede0f4b467 rdf:first html:StyleSheet ;
         rdf:rest () .
 
     _:nee06a6e3cdbc4e7bb4f60cae8aede0f4b468 a owl:Class ;

--- a/tools/RDF2HTML/output/HTML-forms-template-example-serialized.trig
+++ b/tools/RDF2HTML/output/HTML-forms-template-example-serialized.trig
@@ -5489,7 +5489,7 @@ html:Element
     ├── html:Template
     ├── html:RawTextElement
     │    ├── html:Script
-    │    └── html:Style
+    │    └── html:StyleSheet
     ├── html:ForeignElement
     │    ├── mathml:MathML
     │    └── svg:Svg
@@ -6501,7 +6501,7 @@ The RDFa vocabulary is an RDF-based representation of RDFa, a W3C standard for r
     _:n42a422df9dd9487092b155c343a0a6deb249 rdf:first html:Em ;
         rdf:rest _:n42a422df9dd9487092b155c343a0a6deb250 .
 
-    _:n42a422df9dd9487092b155c343a0a6deb25 rdf:first html:Style ;
+    _:n42a422df9dd9487092b155c343a0a6deb25 rdf:first html:StyleSheet ;
         rdf:rest _:n42a422df9dd9487092b155c343a0a6deb26 .
 
     _:n42a422df9dd9487092b155c343a0a6deb250 rdf:first html:Embed ;
@@ -7224,7 +7224,7 @@ The RDFa vocabulary is an RDF-based representation of RDFa, a W3C standard for r
     _:n42a422df9dd9487092b155c343a0a6deb466 rdf:first html:Script ;
         rdf:rest _:n42a422df9dd9487092b155c343a0a6deb467 .
 
-    _:n42a422df9dd9487092b155c343a0a6deb467 rdf:first html:Style ;
+    _:n42a422df9dd9487092b155c343a0a6deb467 rdf:first html:StyleSheet ;
         rdf:rest () .
 
     _:n42a422df9dd9487092b155c343a0a6deb468 a owl:Class ;

--- a/tools/RDF2HTML/output/HTML-table-template-example-serialized.trig
+++ b/tools/RDF2HTML/output/HTML-table-template-example-serialized.trig
@@ -5833,7 +5833,7 @@ html:Element
     ├── html:Template
     ├── html:RawTextElement
     │    ├── html:Script
-    │    └── html:Style
+    │    └── html:StyleSheet
     ├── html:ForeignElement
     │    ├── mathml:MathML
     │    └── svg:Svg
@@ -6845,7 +6845,7 @@ The RDFa vocabulary is an RDF-based representation of RDFa, a W3C standard for r
     _:ne7d5c9557a7244d28bf2c3ca47cc1a30b249 rdf:first html:Em ;
         rdf:rest _:ne7d5c9557a7244d28bf2c3ca47cc1a30b250 .
 
-    _:ne7d5c9557a7244d28bf2c3ca47cc1a30b25 rdf:first html:Style ;
+    _:ne7d5c9557a7244d28bf2c3ca47cc1a30b25 rdf:first html:StyleSheet ;
         rdf:rest _:ne7d5c9557a7244d28bf2c3ca47cc1a30b26 .
 
     _:ne7d5c9557a7244d28bf2c3ca47cc1a30b250 rdf:first html:Embed ;
@@ -7568,7 +7568,7 @@ The RDFa vocabulary is an RDF-based representation of RDFa, a W3C standard for r
     _:ne7d5c9557a7244d28bf2c3ca47cc1a30b466 rdf:first html:Script ;
         rdf:rest _:ne7d5c9557a7244d28bf2c3ca47cc1a30b467 .
 
-    _:ne7d5c9557a7244d28bf2c3ca47cc1a30b467 rdf:first html:Style ;
+    _:ne7d5c9557a7244d28bf2c3ca47cc1a30b467 rdf:first html:StyleSheet ;
         rdf:rest () .
 
     _:ne7d5c9557a7244d28bf2c3ca47cc1a30b468 a owl:Class ;

--- a/tools/RDF2HTML/output/HelloWorld-serialized.trig
+++ b/tools/RDF2HTML/output/HelloWorld-serialized.trig
@@ -5340,7 +5340,7 @@ html:Element
     ├── html:Template
     ├── html:RawTextElement
     │    ├── html:Script
-    │    └── html:Style
+    │    └── html:StyleSheet
     ├── html:ForeignElement
     │    ├── mathml:MathML
     │    └── svg:Svg
@@ -6352,7 +6352,7 @@ The RDFa vocabulary is an RDF-based representation of RDFa, a W3C standard for r
     _:n718bd06a06474301b506b6f3662c39a7b249 rdf:first html:Em ;
         rdf:rest _:n718bd06a06474301b506b6f3662c39a7b250 .
 
-    _:n718bd06a06474301b506b6f3662c39a7b25 rdf:first html:Style ;
+    _:n718bd06a06474301b506b6f3662c39a7b25 rdf:first html:StyleSheet ;
         rdf:rest _:n718bd06a06474301b506b6f3662c39a7b26 .
 
     _:n718bd06a06474301b506b6f3662c39a7b250 rdf:first html:Embed ;
@@ -7075,7 +7075,7 @@ The RDFa vocabulary is an RDF-based representation of RDFa, a W3C standard for r
     _:n718bd06a06474301b506b6f3662c39a7b466 rdf:first html:Script ;
         rdf:rest _:n718bd06a06474301b506b6f3662c39a7b467 .
 
-    _:n718bd06a06474301b506b6f3662c39a7b467 rdf:first html:Style ;
+    _:n718bd06a06474301b506b6f3662c39a7b467 rdf:first html:StyleSheet ;
         rdf:rest () .
 
     _:n718bd06a06474301b506b6f3662c39a7b468 a owl:Class ;


### PR DESCRIPTION
This PR fixes a small internal inconsistency around the HTML `<style>` element.

The current vocabulary uses `html:StyleSheet` as the canonical class for the `<style>` element. This PR keeps that strategy and updates the remaining inconsistent reference from `html:Style` to `html:StyleSheet`.

It intentionally does not rename `html:StyleSheet` to `html:Style`, because `html:StyleSheet` is already used by persisted RDF data outside this repository. The broader IRI naming strategy should be discussed separately in the Community Group.

Validation performed:

* Confirmed lowercase `html:style` attribute references remain untouched.
* Parsed the touched TriG files with RDFLib.
* Confirmed `doc:style a html:StyleSheet` serializes to a `<style>` element.
